### PR TITLE
[WIP] feat(tsdb): Add support for deleting OOO data

### DIFF
--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -128,9 +128,6 @@ type Head struct {
 	writeNotified wlog.WriteNotified
 
 	memTruncationInProcess atomic.Bool
-
-	// Field to store OOO chunks
-	oooChunks []*OOOChunk // or use a map if that's more appropriate
 }
 
 type ExemplarStorage interface {
@@ -1526,15 +1523,6 @@ func (h *Head) Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Match
 	}
 	for _, s := range stones {
 		h.tombstones.AddInterval(s.Ref, s.Intervals[0])
-	}
-
-	// New code for OOO data deletion
-	for _, oooChunk := range h.oooChunks {
-		oooChunk.DeleteRange(mint, maxt, oooChunk.seriesRef)
-		// If using WAL, log the deletion for OOO data
-		// if h.wal != nil {
-		// 	// TODO: Log the new tombstone for OOO data to WAL
-		// }
 	}
 
 	return nil

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -128,6 +128,9 @@ type Head struct {
 	writeNotified wlog.WriteNotified
 
 	memTruncationInProcess atomic.Bool
+
+	// Field to store OOO chunks
+	oooChunks []*OOOChunk // or use a map if that's more appropriate
 }
 
 type ExemplarStorage interface {
@@ -1523,6 +1526,15 @@ func (h *Head) Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Match
 	}
 	for _, s := range stones {
 		h.tombstones.AddInterval(s.Ref, s.Intervals[0])
+	}
+
+	// New code for OOO data deletion
+	for _, oooChunk := range h.oooChunks {
+		oooChunk.DeleteRange(mint, maxt, oooChunk.seriesRef)
+		// If using WAL, log the deletion for OOO data
+		// if h.wal != nil {
+		// 	// TODO: Log the new tombstone for OOO data to WAL
+		// }
 	}
 
 	return nil

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -5832,3 +5832,85 @@ func TestHeadCompactableDoesNotCompactEmptyHead(t *testing.T) {
 
 	require.False(t, head.compactable())
 }
+
+func TestHeadDeleteOOOSamples(t *testing.T) {
+	// Initialize a temporary directory and Write-Ahead Logs (WAL)
+	dir := t.TempDir()
+	wal, err := wlog.NewSize(nil, nil, filepath.Join(dir, "wal"), 32768, wlog.CompressionSnappy)
+	require.NoError(t, err)
+	oooWlog, err := wlog.NewSize(nil, nil, filepath.Join(dir, wlog.WblDirName), 32768, wlog.CompressionSnappy)
+	require.NoError(t, err)
+
+	// Set up Head options
+	opts := DefaultHeadOptions()
+	opts.ChunkDirRoot = dir
+	opts.OutOfOrderCapMax.Store(30)
+	opts.OutOfOrderTimeWindow.Store(120 * time.Minute.Milliseconds())
+
+	// Create a new Head
+	head, err := NewHead(nil, nil, wal, oooWlog, opts, nil)
+	require.NoError(t, err)
+	require.NoError(t, head.Init(0))
+
+	// Label the samples
+	lbls := labels.FromStrings("foo", "bar")
+
+	// Append some initial in-order samples
+	app := head.Appender(context.Background())
+	_, err = app.Append(0, lbls, 10, 1)
+	require.NoError(t, err)
+	_, err = app.Append(0, lbls, 15, 2)
+	require.NoError(t, err)
+	_, err = app.Append(0, lbls, 5, 3) // This is actually out-of-order
+	require.NoError(t, err)
+	err = app.Commit()
+	require.NoError(t, err)
+
+	// Append a batch of out-of-order samples
+	for i := 0; i < 30; i++ {
+		app = head.Appender(context.Background())
+		_, err = app.Append(0, lbls, int64(9-i), float64(9-i)) // These will be out-of-order
+		require.NoError(t, err)
+		err = app.Commit()
+		require.NoError(t, err)
+	}
+
+	// Create a matcher to select samples by labels
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"),
+	}
+
+	var minInt int64 = -20
+	var maxInt int64 = 9
+
+	// Delete samples in a certain time range, including out-of-order ones
+	err = head.Delete(context.Background(), minInt, maxInt, matchers...)
+	require.NoError(t, err)
+
+	// Query to get the remaining samples
+	q, err := NewBlockQuerier(head, head.MinTime(), head.MaxTime())
+	require.NoError(t, err)
+	set := q.Select(context.Background(), false, nil, matchers...)
+	require.NoError(t, q.Close())
+
+	// Check that the remaining samples are as expected
+	valueType := set.Next()
+	require.NotEqual(t, chunkenc.ValNone, valueType)
+
+	series := set.At()
+	it := series.Iterator(nil)
+	remainT := []int64{}
+	remainV := []float64{}
+
+	for valueType := it.Next(); valueType != chunkenc.ValNone; valueType = it.Next() {
+		t, v := it.At()
+		remainT = append(remainT, t)
+		remainV = append(remainV, v)
+	}
+
+	require.Equal(t, []int64{10, 15}, remainT)
+	require.Equal(t, []float64{1, 2}, remainV)
+
+	// Close the head to clean up resources
+	require.NoError(t, head.Close())
+}

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -47,8 +47,8 @@ func NewOOOChunk() *OOOChunk {
 // Returns false if insert was not possible due to the same timestamp already existing
 // or the timestamp falls within a tombstone interval.
 func (o *OOOChunk) Insert(t int64, v float64) bool {
-	// Check if the timestamp falls within any of the tombstone intervals.
-	if o.tombstones.IsDeletedAt(o.seriesRef, t) {
+	// Check if this timestamp is in a tombstone interval before inserting.
+	if o.tombstones.HasTimestamp(o.seriesRef, t) {
 		return false
 	}
 
@@ -129,16 +129,18 @@ type OOORangeHead struct {
 	mint, maxt int64
 
 	isoState *oooIsolationState
+	tombstones tombstones.Reader
 }
 
 func NewOOORangeHead(head *Head, mint, maxt int64, minRef chunks.ChunkDiskMapperRef) *OOORangeHead {
 	isoState := head.oooIso.TrackReadAfter(minRef)
 
 	return &OOORangeHead{
-		head:     head,
-		mint:     mint,
-		maxt:     maxt,
+		head:           head,
+		mint:           mint,
+		maxt:           maxt,
 		isoState: isoState,
+		tombstones: head.tombstones,
 	}
 }
 
@@ -151,9 +153,8 @@ func (oh *OOORangeHead) Chunks() (ChunkReader, error) {
 }
 
 func (oh *OOORangeHead) Tombstones() (tombstones.Reader, error) {
-	// As stated in the design doc https://docs.google.com/document/d/1Kppm7qL9C-BJB1j6yb6-9ObG3AbdZnFUBYPNNWwDBYM/edit?usp=sharing
-	// Tombstones are not supported for out of order metrics.
-	return tombstones.NewMemTombstones(), nil
+	// Return the tombstones from the main head.
+	return oh.tombstones, nil
 }
 
 var oooRangeHeadULID = ulid.MustParse("0000000000XXXX000RANGEHEAD")
@@ -187,17 +188,4 @@ func (oh *OOORangeHead) MinTime() int64 {
 
 func (oh *OOORangeHead) MaxTime() int64 {
 	return oh.maxt
-}
-
-func (o *OOOChunk) DeleteRange(mint, maxt int64, seriesRef storage.SeriesRef) {
-	var newSamples []sample
-	for _, s := range o.samples {
-		if s.t < mint || s.t > maxt {
-			newSamples = append(newSamples, s)
-		} else {
-			// Optionally, update the tombstones here if you are maintaining a tombstone list in OOOChunk
-			o.tombstones.AddInterval(seriesRef, tombstones.Interval{Mint: mint, Maxt: maxt})
-		}
-	}
-	o.samples = newSamples
 }

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/oklog/ulid"
 
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
@@ -29,16 +30,28 @@ import (
 // Samples are stored uncompressed to allow easy sorting.
 // Perhaps we can be more efficient later.
 type OOOChunk struct {
-	samples []sample
+	samples    []sample
+	tombstones *tombstones.MemTombstones
+	seriesRef  storage.SeriesRef
 }
 
 func NewOOOChunk() *OOOChunk {
-	return &OOOChunk{samples: make([]sample, 0, 4)}
+	// return &OOOChunk{samples: make([]sample, 0, 4)}
+	return &OOOChunk{
+		samples:    make([]sample, 0, 4),
+		tombstones: tombstones.NewMemTombstones(),
+	}
 }
 
 // Insert inserts the sample such that order is maintained.
-// Returns false if insert was not possible due to the same timestamp already existing.
+// Returns false if insert was not possible due to the same timestamp already existing
+// or the timestamp falls within a tombstone interval.
 func (o *OOOChunk) Insert(t int64, v float64) bool {
+	// Check if the timestamp falls within any of the tombstone intervals.
+	if o.tombstones.IsDeletedAt(o.seriesRef, t) {
+		return false
+	}
+
 	// Although out-of-order samples can be out-of-order amongst themselves, we
 	// are opinionated and expect them to be usually in-order meaning we could
 	// try to append at the end first if the new timestamp is higher than the
@@ -174,4 +187,17 @@ func (oh *OOORangeHead) MinTime() int64 {
 
 func (oh *OOORangeHead) MaxTime() int64 {
 	return oh.maxt
+}
+
+func (o *OOOChunk) DeleteRange(mint, maxt int64, seriesRef storage.SeriesRef) {
+	var newSamples []sample
+	for _, s := range o.samples {
+		if s.t < mint || s.t > maxt {
+			newSamples = append(newSamples, s)
+		} else {
+			// Optionally, update the tombstones here if you are maintaining a tombstone list in OOOChunk
+			o.tombstones.AddInterval(seriesRef, tombstones.Interval{Mint: mint, Maxt: maxt})
+		}
+	}
+	o.samples = newSamples
 }

--- a/tsdb/tombstones/tombstones.go
+++ b/tsdb/tombstones/tombstones.go
@@ -385,3 +385,19 @@ func (in Intervals) Add(n Interval) Intervals {
 	}
 	return append(in[:mini+1], in[maxi+mini:]...)
 }
+
+// IsDeletedAt checks if the given timestamp for the series reference is deleted.
+func (t *MemTombstones) IsDeletedAt(ref storage.SeriesRef, timestamp int64) bool {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+	intervals, ok := t.intvlGroups[ref]
+	if !ok {
+		return false
+	}
+	for _, interval := range intervals {
+		if interval.InBounds(timestamp) {
+			return true
+		}
+	}
+	return false
+}

--- a/tsdb/tombstones/tombstones.go
+++ b/tsdb/tombstones/tombstones.go
@@ -386,16 +386,18 @@ func (in Intervals) Add(n Interval) Intervals {
 	return append(in[:mini+1], in[maxi+mini:]...)
 }
 
-// IsDeletedAt checks if the given timestamp for the series reference is deleted.
-func (t *MemTombstones) IsDeletedAt(ref storage.SeriesRef, timestamp int64) bool {
+// Check if a given timestamp is within any of the tombstone intervals.
+func (t *MemTombstones) HasTimestamp(ref storage.SeriesRef, ts int64) bool {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
-	intervals, ok := t.intvlGroups[ref]
-	if !ok {
+
+	intervals, exists := t.intvlGroups[ref]
+	if !exists {
 		return false
 	}
+
 	for _, interval := range intervals {
-		if interval.InBounds(timestamp) {
+		if ts >= interval.Mint && ts <= interval.Maxt {
 			return true
 		}
 	}


### PR DESCRIPTION
### Description
This PR introduces the ability to delete out-of-order (OOO) data within a specified time range. The feature extends the existing Delete function in the Head struct, allowing users to remove both in-order and OOO samples from memory and optionally from the Write-Ahead Log (WAL).

### Related Issue
Closes 11790 
Replaces 12835

### Proposed Changes
1. Added `DeleteRange` method to `OOOChunk` to remove samples in a specified time range.
2. Extended the Delete method in the Head struct to also remove OOO data, if present.
3. Added WAL support for OOO data deletion (Optional).

### Proof Manifests
#### How to Test
1. Execute `curl -X POST -g 'http://localhost:9090/api/v1/admin/tsdb/delete_series?match[]=<MERTIC>'`, replace MERTIC with the metric you want to delete

![Screenshot from 2023-09-13 12-25-59](https://github.com/infracloudio/prometheus-oss/assets/46122307/e20c31f2-3100-4473-bd87-32136b9985ae)
![Screenshot from 2023-09-13 12-27-03](https://github.com/infracloudio/prometheus-oss/assets/46122307/9d75d479-4050-4a66-b084-72ed67f00a06)
![Screenshot from 2023-09-13 12-26-25](https://github.com/infracloudio/prometheus-oss/assets/46122307/b0c4a75e-1b99-4d4c-87c4-f5cba45a1847)
<!--
    Don't forget!

    - Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --signoff flag to `git commit`. See https://github.com/apps/dco for more information.

    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.

    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.

    - No tests are needed for internal implementation changes.

    - Performance improvements would need a benchmark test to prove it.

    - All exposed objects should have a comment.

    - All comments should start with a capital letter and end with a full stop.
 -->
